### PR TITLE
Ensure that key_prefix is a prefix even if it's a callable.

### DIFF
--- a/flask_caching/__init__.py
+++ b/flask_caching/__init__.py
@@ -416,8 +416,9 @@ class Cache(object):
 
             def _make_cache_key(args, kwargs, use_request):
                 if callable(key_prefix):
-                    cache_key = key_prefix()
-                elif '%s' in key_prefix:
+                    key_prefix = key_prefix()
+                
+                if '%s' in key_prefix:
                     if use_request:
                         cache_key = key_prefix % request.path
                     else:


### PR DESCRIPTION
Fix that key_prefix override the cache_key entirely if and only if, it's a callable.